### PR TITLE
Default params

### DIFF
--- a/lib/imgui_helpers.lua
+++ b/lib/imgui_helpers.lua
@@ -64,10 +64,9 @@ imgui_helpers.do_preview = function(ctx, obj, change)
       return false
     end
     local left = reaper.ImGui_MouseButton_Left()
-    --local not_drag_changed = reaper.ImGui_IsItemActive(ctx) ~= reacoma.settings.drag_preview
     local drag_preview = change > 0 and reacoma.settings.drag_preview
-    local end_drag_preview = not reacoma.settings.drag_preview and reaper.ImGui_IsMouseReleased(ctx, left) and reacoma.settings.preview_pending
-    reacoma.settings.preview_pending = not end_drag_preview and (reacoma.settings.preview_pending or (change > 0 and not reacoma.settings.drag_preview))
+    local end_drag_preview = not reacoma.settings.immediate_preview and not reaper.ImGui_IsMouseDown(ctx, left) and reacoma.settings.preview_pending
+    reacoma.settings.preview_pending = not end_drag_preview and (reacoma.settings.preview_pending or (change > 0 and not reacoma.settings.immediate_preview))
     return drag_preview or end_drag_preview
 end
 

--- a/lib/imgui_helpers.lua
+++ b/lib/imgui_helpers.lua
@@ -70,9 +70,9 @@ imgui_helpers.do_preview = function(ctx, obj, change)
     return drag_preview or end_drag_preview
 end
 
-imgui_helpers.update_state = function(ctx, obj)
+imgui_helpers.update_state = function(ctx, obj, update)
     local change = imgui_helpers.draw_gui(ctx, obj)
-    if imgui_helpers.do_preview(ctx, obj, change) then
+    if imgui_helpers.do_preview(ctx, obj, change + utils.bool_to_number[update]) then
         return obj.perform_update(obj.parameters)
     end
 end

--- a/lib/imgui_wrapper.lua
+++ b/lib/imgui_wrapper.lua
@@ -110,16 +110,16 @@ imgui_wrapper.loop = function(ctx, viewport, state, obj)
                 reaper.ImGui_BeginDisabled(ctx)
             end
             reaper.ImGui_SameLine(ctx)
-            _,  reacoma.settings.drag_preview = reaper.ImGui_Checkbox(ctx,
+            _,  reacoma.settings.immediate_preview = reaper.ImGui_Checkbox(ctx,
                 'immediate',
-                reacoma.settings.drag_preview
+                reacoma.settings.immediate_preview
             )
             if not reacoma.settings.slice_preview then
                 reaper.ImGui_EndDisabled(ctx)
             end
         else
             reacoma.settings.slice_preview = false
-            reacoma.settings.drag_preview = false
+            reacoma.settings.immediate_preview = false
         end
         state = reacoma.imgui_helpers.update_state(ctx, obj, reacoma.settings.slice_preview)
         reaper.ImGui_End(ctx)
@@ -135,6 +135,7 @@ imgui_wrapper.loop = function(ctx, viewport, state, obj)
         reaper.Undo_EndBlock2(0, obj.info.ext_name, 4)
         reacoma.params.set(obj)
         reaper.SetExtState('reacoma', 'slice_preview', utils.bool_to_string[reacoma.settings.slice_preview], true)
+        reaper.SetExtState('reacoma', 'immediate_preview', utils.bool_to_string[reacoma.settings.immediate_preview], true)
         return
     end
 end

--- a/lib/imgui_wrapper.lua
+++ b/lib/imgui_wrapper.lua
@@ -96,6 +96,8 @@ imgui_wrapper.loop = function(ctx, viewport, state, obj)
 
         visible, open = reaper.ImGui_Begin(ctx, obj.info.algorithm_name, true, r.ImGui_WindowFlags_NoCollapse())
 
+        local restored = false
+        
         if reaper.ImGui_Button(ctx, obj.info.action) or (reacoma.global_state.active == 0 and reaper.ImGui_IsKeyPressed(ctx, 13)) then
             state = reacoma.imgui_helpers.process(obj) -- TODO: make this respond to slicer/layers
         end
@@ -121,7 +123,13 @@ imgui_wrapper.loop = function(ctx, viewport, state, obj)
             reacoma.settings.slice_preview = false
             reacoma.settings.immediate_preview = false
         end
-        state = reacoma.imgui_helpers.update_state(ctx, obj, reacoma.settings.slice_preview)
+        if obj.defaults ~= nil then
+            if reaper.ImGui_Button(ctx, "defaults") then
+                state = params.restore_defaults(obj)
+                restored = true
+            end
+        end
+        state = reacoma.imgui_helpers.update_state(ctx, obj, restored)
         reaper.ImGui_End(ctx)
     end
     if open then

--- a/lib/params.lua
+++ b/lib/params.lua
@@ -14,4 +14,23 @@ params.get = function(obj)
     end
 end
 
+params.store_defaults = function(obj)
+    idx = 1
+    defaults = {}
+    for parameter, d in pairs(obj.parameters) do
+        defaults[idx] = d.value
+        idx = idx + 1
+    end
+    obj.defaults = defaults
+end
+
+params.restore_defaults = function(obj)
+    idx = 1
+    for parameter, d in pairs(obj.parameters) do
+        d.value = obj.defaults[idx]
+        idx = idx + 1
+    end
+end
+
+
 return params

--- a/lib/reacoma.lua
+++ b/lib/reacoma.lua
@@ -31,12 +31,14 @@ reacoma.settings.path = reaper.GetExtState("reacoma", "exepath")
 if reaper.HasExtState("reacoma", "slice_preview") then
     local preview = reaper.GetExtState("reacoma", "slice_preview")
     if preview == 'false' then preview = false else preview = true end
+    local immediate = reaper.GetExtState("reacoma", "immediate_preview")
+    if immediate == 'false' then immediate = false else immediate = true end
     reacoma.settings.slice_preview = preview
-    reacoma.settings.drag_preview = preview
+    reacoma.settings.immediate_preview = immediate
     reacoma.settings.preview_pending = false
 else
     reacoma.settings.slice_preview = false
-    reacoma.settings.drag_preview = false
+    reacoma.settings.immediate_preview = false
     reacoma.settings.preview_pending = false
 end
 


### PR DESCRIPTION
This PR adds the option for modules to add a button that will restore the default parameters.

To do so use:

```
obj = reacoma.nameofmodule
params.store_defaults(obj)
```

In the main script (only the second line is new)

Everything else should be automagic. Previews (if on) will update when this button is pressed.
