### PR TITLE
Reduce slicing code repetition by creating a common function (slicing.convert)

### DIFF
--- a/lib/slicing.lua
+++ b/lib/slicing.lua
@@ -16,22 +16,8 @@ slicing.rm_dup = function(slice_table)
     return res
 end
 
-slicing.gateslice = function(data)
-    local onsets_and_offsets = reacoma.utils.split_space(
-        data.slice_points_string
-    )
-
-    -- Interleave the onsets/offsets
-    local slice_points = reacoma.utils.lace_tables(
-        reacoma.utils.split_comma(onsets_and_offsets[1]),
-        reacoma.utils.split_comma(onsets_and_offsets[2])
-    )
-
-    -- Also test if the slice points are logical, otherwise exit
-    if gate_based_slicer and (slice_points[1] == '-1' or slice_points[2] == '-1') then 
-        return 
-    end
-
+slicing.convert = function(slice_points, data)
+    
     -- Invert the table around the middle point (mirror!)
     if data.reverse == true then
         for i=1, #slice_points do
@@ -61,6 +47,26 @@ slicing.gateslice = function(data)
             data.sr
         )
     end
+    return slice_points
+end
+
+slicing.gateslice = function(data)
+    local onsets_and_offsets = reacoma.utils.split_space(
+        data.slice_points_string
+    )
+
+    -- Interleave the onsets/offsets
+    local slice_points = reacoma.utils.lace_tables(
+        reacoma.utils.split_comma(onsets_and_offsets[1]),
+        reacoma.utils.split_comma(onsets_and_offsets[2])
+    )
+
+    -- Also test if the slice points are logical, otherwise exit
+    if gate_based_slicer and (slice_points[1] == '-1' or slice_points[2] == '-1') then 
+        return 
+    end
+
+    slice_points = slicing.convert(slice_points, data)
 
     for i=1, #slice_points do
         local slice_pos = slice_points[i]
@@ -79,35 +85,7 @@ end
 slicing.process = function(data)
     local slice_points = reacoma.utils.split_comma(data.slice_points_string)
 
-    -- Invert the table around the middle point (mirror!)
-    if data.reverse == true then
-        for i=1, #slice_points do
-            slice_points[i] = (
-                data.item_len_samples - slice_points[i]
-            )   
-        end
-        reacoma.utils.reverse_table(slice_points)
-    end
-    
-    -- if the left boundary is the start remove it
-    -- This protects situations where the slice point is implicit in the boundaries of the media item
-    if tonumber(slice_points[1]) == data.take_ofs_samples then 
-        table.remove(slice_points, 1) 
-    end
-
-    -- now sanitise the numbers to adjust for the take offset and playback rate
-    for i=1, #slice_points do
-        if data.reverse == true then
-            slice_points[i] = (slice_points[i] + data.take_ofs_samples) / data.playrate
-        else
-            slice_points[i] = (slice_points[i] - data.take_ofs_samples) / data.playrate
-        end
-        -- and convert to seconds for REAPER
-        slice_points[i] = reacoma.utils.sampstos(
-            slice_points[i],
-            data.sr
-        )
-    end
+    slice_points = slicing.convert(slice_points, data)
 
     for i=1, #slice_points do
         local slice_pos = slice_points[i]


### PR DESCRIPTION
There is a large block of repeated code in slicing.lua that can be removed by putting the common code in its own function.

This PR addresses this (although it is worth checking carefully). I've done a few stages of automatic comparison to be sure that the code is an exact copy, so I don't believe there should be an issue in principle, but checking that the correct bits have been copied would be worthwhile.